### PR TITLE
Bump Wagtail version in setup py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 2",
     ],
-    install_requires=["Django>=3.0,<4.0", "Wagtail>=2.14,<2.16"],
+    install_requires=["Django>=3.0,<4.0", "Wagtail>=2.14,<2.18"],
     extras_require={
         "testing": ["dj-database-url==0.5.0", "freezegun==0.3.15"],
     },


### PR DESCRIPTION
Went a bit conservative.
Since the goal is to remove it in 2.17, we should allow install on 2.16/17

note: made this change via the UI, so tox.ini is not up-to-date